### PR TITLE
refactor(vite配置): 移除vue-demi的CDN外部依赖

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,9 +57,6 @@ export default defineConfig(async ({ mode }) => ({
         externalGlobals: {
           vue: cdn
             .jsdelivr('Vue', 'dist/vue.global.prod.js')
-            .concat(
-              cdn.jsdelivr('', 'lib/index.iife.js')[1]('latest', 'vue-demi'),
-            )
             .concat(util.dataUrl(';window.Vue=Vue;')),
           'element-plus': cdn.jsdelivr('ElementPlus', 'dist/index.full.min.js'),
         },


### PR DESCRIPTION
简化外部依赖配置，删除不再需要的vue-demi引用